### PR TITLE
Modernize UI with calendar and kanban board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+data.sqlite
+backup/*.sqlite

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# SM Manager
+
+Prosta aplikacja do zarządzania treściami dla solo twórcy.
+
+## Funkcje
+- Planowanie publikacji (posts)
+- Bank pomysłów (ideas)
+- Lista zadań (todos)
+- Szablony tygodniowe (templates)
+- Eksport do CSV/ICS
+- Backup bazy danych
+
+Login domyślny: `admin` / `password`.

--- a/api/export.php
+++ b/api/export.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../db.php';
+require_login();
+$db = get_db();
+$type = $_GET['type'] ?? 'csv';
+
+if ($type === 'csv') {
+    header('Content-Type: text/csv');
+    header('Content-Disposition: attachment; filename="posts.csv"');
+    $out = fopen('php://output', 'w');
+    fputcsv($out, ['id','platform','title','description','publish_date','status','tags','series_id']);
+    foreach ($db->query('SELECT * FROM posts') as $row) {
+        fputcsv($out, $row);
+    }
+    fclose($out);
+    exit;
+}
+
+if ($type === 'ics') {
+    header('Content-Type: text/calendar');
+    header('Content-Disposition: attachment; filename="posts.ics"');
+    echo "BEGIN:VCALENDAR\nVERSION:2.0\n";
+    $stmt = $db->query("SELECT * FROM posts WHERE publish_date!=''");
+    foreach ($stmt as $row) {
+        $date = date('Ymd\THis', strtotime($row['publish_date']));
+        echo "BEGIN:VEVENT\nUID:post{$row['id']}@sm_manager\nDTSTART:$date\nSUMMARY:{$row['title']}\nEND:VEVENT\n";
+    }
+    echo "END:VCALENDAR";
+    exit;
+}
+
+http_response_code(400);
+echo json_encode(['error'=>'unknown type']);
+?>

--- a/api/ideas.php
+++ b/api/ideas.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/../db.php';
+require_login();
+header('Content-Type: application/json');
+$db = get_db();
+$method = $_SERVER['REQUEST_METHOD'];
+
+switch ($method) {
+    case 'GET':
+        $stmt = $db->query('SELECT * FROM ideas ORDER BY created_at DESC');
+        echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+        break;
+    case 'POST':
+        $data = json_decode(file_get_contents('php://input'), true);
+        $stmt = $db->prepare('INSERT INTO ideas (title, description, category) VALUES (?,?,?)');
+        $stmt->execute([
+            $data['title'] ?? '',
+            $data['description'] ?? '',
+            $data['category'] ?? ''
+        ]);
+        echo json_encode(['id' => $db->lastInsertId()]);
+        break;
+    case 'DELETE':
+        $id = $_GET['id'] ?? 0;
+        $stmt = $db->prepare('DELETE FROM ideas WHERE id=?');
+        $stmt->execute([$id]);
+        echo json_encode(['success' => true]);
+        break;
+    default:
+        http_response_code(405);
+        echo json_encode(['error' => 'Method not allowed']);
+}
+?>

--- a/api/posts.php
+++ b/api/posts.php
@@ -1,0 +1,58 @@
+<?php
+require_once __DIR__ . '/../db.php';
+require_login();
+header('Content-Type: application/json');
+$db = get_db();
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+switch ($method) {
+    case 'GET':
+        $stmt = $db->query('SELECT * FROM posts ORDER BY publish_date');
+        echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+        break;
+    case 'POST':
+        $data = json_decode(file_get_contents('php://input'), true);
+        $stmt = $db->prepare('INSERT INTO posts (platform, title, description, publish_date, status, tags, series_id) VALUES (?,?,?,?,?,?,?)');
+        $stmt->execute([
+            $data['platform'] ?? '',
+            $data['title'] ?? '',
+            $data['description'] ?? '',
+            $data['publish_date'] ?? '',
+            $data['status'] ?? 'idea',
+            $data['tags'] ?? '',
+            $data['series_id'] ?? null
+        ]);
+        echo json_encode(['id' => $db->lastInsertId()]);
+        break;
+    case 'PUT':
+        $id = $_GET['id'] ?? 0;
+        $data = json_decode(file_get_contents('php://input'), true);
+        $stmt = $db->prepare('SELECT * FROM posts WHERE id=?');
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
+        $data = array_merge($row, $data);
+        $stmt = $db->prepare('UPDATE posts SET platform=?, title=?, description=?, publish_date=?, status=?, tags=?, series_id=? WHERE id=?');
+        $stmt->execute([
+            $data['platform'] ?? '',
+            $data['title'] ?? '',
+            $data['description'] ?? '',
+            $data['publish_date'] ?? '',
+            $data['status'] ?? '',
+            $data['tags'] ?? '',
+            $data['series_id'] ?? null,
+            $id
+        ]);
+        echo json_encode(['success' => true]);
+        break;
+    case 'DELETE':
+        $id = $_GET['id'] ?? 0;
+        $stmt = $db->prepare('DELETE FROM posts WHERE id=?');
+        $stmt->execute([$id]);
+        echo json_encode(['success' => true]);
+        break;
+    default:
+        http_response_code(405);
+        echo json_encode(['error' => 'Method not allowed']);
+}
+?>

--- a/api/templates.php
+++ b/api/templates.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/../db.php';
+require_login();
+header('Content-Type: application/json');
+$db = get_db();
+$method = $_SERVER['REQUEST_METHOD'];
+
+switch ($method) {
+    case 'GET':
+        $stmt = $db->query('SELECT * FROM templates');
+        echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+        break;
+    case 'POST':
+        $data = json_decode(file_get_contents('php://input'), true);
+        $stmt = $db->prepare('INSERT INTO templates (name, weekdays, platforms) VALUES (?,?,?)');
+        $stmt->execute([
+            $data['name'] ?? '',
+            $data['weekdays'] ?? '',
+            $data['platforms'] ?? ''
+        ]);
+        echo json_encode(['id' => $db->lastInsertId()]);
+        break;
+    case 'DELETE':
+        $id = $_GET['id'] ?? 0;
+        $stmt = $db->prepare('DELETE FROM templates WHERE id=?');
+        $stmt->execute([$id]);
+        echo json_encode(['success' => true]);
+        break;
+    default:
+        http_response_code(405);
+        echo json_encode(['error' => 'Method not allowed']);
+}
+?>

--- a/api/todos.php
+++ b/api/todos.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/../db.php';
+require_login();
+header('Content-Type: application/json');
+$db = get_db();
+$method = $_SERVER['REQUEST_METHOD'];
+
+switch ($method) {
+    case 'GET':
+        $stmt = $db->query('SELECT * FROM todos ORDER BY due_date');
+        echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+        break;
+    case 'POST':
+        $data = json_decode(file_get_contents('php://input'), true);
+        $stmt = $db->prepare('INSERT INTO todos (title, description, due_date, status) VALUES (?,?,?,?)');
+        $stmt->execute([
+            $data['title'] ?? '',
+            $data['description'] ?? '',
+            $data['due_date'] ?? '',
+            $data['status'] ?? 'open'
+        ]);
+        echo json_encode(['id' => $db->lastInsertId()]);
+        break;
+    case 'PUT':
+        $id = $_GET['id'] ?? 0;
+        $data = json_decode(file_get_contents('php://input'), true);
+        $stmt = $db->prepare('UPDATE todos SET title=?, description=?, due_date=?, status=? WHERE id=?');
+        $stmt->execute([
+            $data['title'] ?? '',
+            $data['description'] ?? '',
+            $data['due_date'] ?? '',
+            $data['status'] ?? '',
+            $id
+        ]);
+        echo json_encode(['success' => true]);
+        break;
+    case 'DELETE':
+        $id = $_GET['id'] ?? 0;
+        $stmt = $db->prepare('DELETE FROM todos WHERE id=?');
+        $stmt->execute([$id]);
+        echo json_encode(['success' => true]);
+        break;
+    default:
+        http_response_code(405);
+        echo json_encode(['error' => 'Method not allowed']);
+}
+?>

--- a/backup.php
+++ b/backup.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__ . '/config.php';
+require_login();
+$dest = __DIR__ . '/backup/' . 'backup_' . date('Ymd_His') . '.sqlite';
+if (copy(DB_FILE, $dest)) {
+    echo 'Backup saved to ' . basename($dest);
+} else {
+    http_response_code(500);
+    echo 'Backup failed';
+}
+?>

--- a/config.php
+++ b/config.php
@@ -1,0 +1,18 @@
+<?php
+session_start();
+
+// Database file path
+const DB_FILE = __DIR__ . '/data.sqlite';
+
+// Simple credentials - change in production
+const APP_USER = 'admin';
+const APP_PASS_HASH = '$2y$12$aO.pPc4/1yrZ0f/TK.9dtuA7iFx3OvCKg7jjSEsKYn7c0Kt3r151.';
+
+function require_login() {
+    if (!isset($_SESSION['user'])) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Unauthorized']);
+        exit;
+    }
+}
+?>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,60 @@
+:root {
+  --bg: #ffffff;
+  --text: #000000;
+  --accent: #0066ff;
+}
+[data-theme="dark"] {
+  --bg: #121212;
+  --text: #e0e0e0;
+  --accent: #3399ff;
+}
+body {
+  margin:0;
+  font-family: 'Inter', Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  transition: background .3s, color .3s;
+}
+nav {
+  display:flex;
+  align-items:center;
+  gap:.5rem;
+  overflow-x:auto;
+  background: var(--accent);
+  color: #fff;
+}
+nav a {
+  padding:1rem;
+  color:#fff;
+  text-decoration:none;
+  white-space:nowrap;
+  opacity:.8;
+}
+nav a.active { opacity:1; border-bottom:2px solid #fff; }
+nav button { margin-left:auto; background:none; border:none; color:#fff; padding:1rem; }
+#content { padding:1rem; max-width:1000px; margin:0 auto; }
+button { cursor:pointer; }
+
+#login { max-width:300px; margin:5rem auto; display:flex; flex-direction:column; gap:.5rem; }
+#login input { padding:.5rem; border:1px solid #ccc; border-radius:4px; }
+#login button { padding:.5rem; background:var(--accent); color:#fff; border:none; border-radius:4px; }
+
+table { width:100%; border-collapse:collapse; }
+table.striped tbody tr:nth-child(odd){ background:rgba(0,0,0,0.05); }
+th, td { padding:.5rem; text-align:left; }
+
+.kanban { display:flex; gap:1rem; overflow-x:auto; }
+.kanban .column { flex:1; min-width:200px; background:rgba(0,0,0,0.05); border-radius:8px; padding:.5rem; }
+.kanban h3 { text-transform:capitalize; text-align:center; }
+.card { background:var(--bg); margin:.5rem 0; padding:.5rem; border-radius:6px; box-shadow:0 1px 3px rgba(0,0,0,0.1); }
+
+.calendar { width:100%; border-collapse:collapse; }
+.calendar th, .calendar td { border:1px solid rgba(0,0,0,0.1); vertical-align:top; height:80px; }
+.calendar .date { font-weight:bold; }
+.cal-post { background:var(--accent); color:#fff; padding:2px 4px; margin:2px 0; border-radius:4px; font-size:.8rem; }
+
+/* Small screens first */
+@media(min-width:600px){
+  nav { justify-content:flex-start; }
+  nav a { padding:1rem 2rem; }
+}

--- a/db.php
+++ b/db.php
@@ -1,0 +1,52 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+function get_db(): PDO {
+    static $db = null;
+    if ($db === null) {
+        $needInit = !file_exists(DB_FILE);
+        $db = new PDO('sqlite:' . DB_FILE);
+        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        if ($needInit) {
+            init_db($db);
+        }
+    }
+    return $db;
+}
+
+function init_db(PDO $db): void {
+    $db->exec("CREATE TABLE IF NOT EXISTS posts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        platform TEXT,
+        title TEXT,
+        description TEXT,
+        publish_date TEXT,
+        status TEXT,
+        tags TEXT,
+        series_id INTEGER
+    )");
+
+    $db->exec("CREATE TABLE IF NOT EXISTS ideas (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT,
+        description TEXT,
+        category TEXT,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )");
+
+    $db->exec("CREATE TABLE IF NOT EXISTS todos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT,
+        description TEXT,
+        due_date TEXT,
+        status TEXT
+    )");
+
+    $db->exec("CREATE TABLE IF NOT EXISTS templates (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT,
+        weekdays TEXT,
+        platforms TEXT
+    )");
+}
+?>

--- a/index.php
+++ b/index.php
@@ -1,1 +1,53 @@
-
+<?php
+require_once __DIR__ . '/db.php';
+$db = get_db();
+?>
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>SM Manager</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="css/styles.css" />
+</head>
+<body data-theme="light">
+<?php if (!isset($_SESSION['user'])): ?>
+<div id="login">
+  <h1>Logowanie</h1>
+  <input id="user" placeholder="Użytkownik" />
+  <input id="pass" type="password" placeholder="Hasło" />
+  <button id="loginBtn">Zaloguj</button>
+  <div id="loginMsg"></div>
+</div>
+<script>
+document.getElementById('loginBtn').addEventListener('click', ()=>{
+  fetch('login.php', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({username:document.getElementById('user').value, password:document.getElementById('pass').value})
+  }).then(r=>{
+    if(r.ok) location.reload();
+    else r.json().then(d=>document.getElementById('loginMsg').innerText=d.error);
+  });
+});
+</script>
+<?php else: ?>
+<nav>
+  <a href="#" data-view="dashboard">Dashboard</a>
+  <a href="#" data-view="calendar">Kalendarz</a>
+  <a href="#" data-view="kanban">Kanban</a>
+  <a href="#" data-view="posts">Posty</a>
+  <a href="#" data-view="ideas">Pomysły</a>
+  <a href="#" data-view="todos">To-do</a>
+  <a href="#" data-view="settings">Ustawienia</a>
+  <a href="#" data-view="reports">Raporty</a>
+  <button id="themeToggle">🌓</button>
+</nav>
+<div id="content">Ładowanie...</div>
+<script src="js/app.js"></script>
+<?php endif; ?>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,158 @@
+let postsCache = [];
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('nav a').forEach(a => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      loadView(a.getAttribute('data-view'));
+    });
+  });
+  document.getElementById('themeToggle').addEventListener('click', () => {
+    document.body.dataset.theme = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+  });
+  loadView('dashboard');
+});
+
+function loadView(view) {
+  fetch('views/' + view + '.html')
+    .then(r => r.text())
+    .then(html => {
+      document.getElementById('content').innerHTML = html;
+      document.querySelectorAll('nav a').forEach(a => a.classList.toggle('active', a.getAttribute('data-view') === view));
+      if (window[view + 'Init']) {
+        window[view + 'Init']();
+      }
+    });
+}
+
+function dashboardInit() {
+  fetch('api/posts.php')
+    .then(r => r.json())
+    .then(data => {
+      const upcoming = data.filter(p => p.status === 'scheduled').slice(0,5);
+      const list = upcoming.map(p => `<li>${p.title} (${p.platform}) - ${p.publish_date}</li>`).join('');
+      document.getElementById('upcoming').innerHTML = `<ul>${list}</ul>`;
+    });
+  fetch('api/todos.php')
+    .then(r=>r.json())
+    .then(data=>{
+      const today = new Date().toISOString().slice(0,10);
+      const list = data.filter(t=>t.due_date===today && t.status!=='done')
+        .map(t=>`<li>${t.title}</li>`).join('');
+      document.getElementById('todayTodos').innerHTML = list || '<li>Brak zadań</li>';
+    });
+}
+
+function postsInit() {
+  fetch('api/posts.php')
+    .then(r => r.json())
+    .then(data => {
+      postsCache = data;
+      renderPosts(data);
+      const search = document.getElementById('postSearch');
+      if (search) {
+        search.addEventListener('input', () => {
+          const term = search.value.toLowerCase();
+          renderPosts(postsCache.filter(p => p.title.toLowerCase().includes(term)));
+        });
+      }
+    });
+}
+
+function ideasInit() {
+  fetch('api/ideas.php')
+    .then(r => r.json())
+    .then(data => {
+      const list = data.map(i => `<li>${i.title}</li>`).join('');
+      document.getElementById('ideasList').innerHTML = list;
+    });
+}
+
+function todosInit() {
+  fetch('api/todos.php')
+    .then(r => r.json())
+    .then(data => {
+      const list = data.map(t => `<li><input type='checkbox' ${t.status==='done'?'checked':''} data-id='${t.id}'/> ${t.title}</li>`).join('');
+      const ul = document.getElementById('todoList');
+      ul.innerHTML = list;
+      ul.querySelectorAll('input').forEach(ch => ch.addEventListener('change', () => {
+        fetch('api/todos.php?id=' + ch.dataset.id, {
+          method:'PUT',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({status: ch.checked ? 'done':'open'})
+        });
+      }));
+    });
+}
+
+function calendarInit() {
+  fetch('api/posts.php')
+    .then(r => r.json())
+    .then(data => {
+      const today = new Date();
+      const year = today.getFullYear();
+      const month = today.getMonth();
+      const firstDay = new Date(year, month, 1);
+      const lastDay = new Date(year, month + 1, 0);
+      let html = '<table class="calendar"><tr>' + ['Pn','Wt','Śr','Cz','Pt','So','Nd'].map(d=>`<th>${d}</th>`).join('') + '</tr><tr>';
+      for (let i = 0; i < (firstDay.getDay() + 6) % 7; i++) html += '<td></td>';
+      for (let d = 1; d <= lastDay.getDate(); d++) {
+        const dateStr = `${year}-${String(month+1).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+        const posts = data.filter(p => p.publish_date === dateStr);
+        html += `<td><div class='date'>${d}</div>${posts.map(p=>`<div class='cal-post'>${p.title}</div>`).join('')}</td>`;
+        if ((d + (firstDay.getDay()+6)%7) % 7 === 0) html += '</tr><tr>';
+      }
+      html += '</tr></table>';
+      document.getElementById('calendar').innerHTML = html;
+    });
+}
+
+function kanbanInit() {
+  const statuses = ['idea','production','ready','scheduled','published'];
+  fetch('api/posts.php')
+    .then(r=>r.json())
+    .then(data => {
+      postsCache = data;
+      const board = document.getElementById('kanban');
+      board.innerHTML = statuses.map(s=>`<div class='column' data-status='${s}'><h3>${s}</h3><div class='col-content'></div></div>`).join('');
+      statuses.forEach(s => {
+        const col = board.querySelector(`[data-status='${s}'] .col-content`);
+        data.filter(p=>p.status===s).forEach(p=>{
+          const card = document.createElement('div');
+          card.className = 'card';
+          card.textContent = p.title;
+          card.draggable = true;
+          card.dataset.id = p.id;
+          card.addEventListener('dragstart', e => e.dataTransfer.setData('id', p.id));
+          col.appendChild(card);
+        });
+      });
+      board.querySelectorAll('.column').forEach(col => {
+        col.addEventListener('dragover', e => e.preventDefault());
+        col.addEventListener('drop', e => {
+          const id = e.dataTransfer.getData('id');
+          const status = col.dataset.status;
+          const post = postsCache.find(p=>p.id==id);
+          fetch('api/posts.php?id=' + id, {
+            method:'PUT',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({...post, status})
+          }).then(()=>kanbanInit());
+        });
+      });
+    });
+}
+
+function renderPosts(data){
+  const rows = data.map(p => `<tr><td>${p.title}</td><td>${p.platform}</td><td>${p.status}</td></tr>`).join('');
+  document.getElementById('postsTable').innerHTML = rows;
+}
+
+document.addEventListener('keydown', e => {
+  if (e.altKey) {
+    const map = {'1':'dashboard','2':'calendar','3':'kanban','4':'posts','5':'ideas','6':'todos','7':'settings','8':'reports'};
+    if (map[e.key]) {
+      loadView(map[e.key]);
+    }
+  }
+});

--- a/login.php
+++ b/login.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $data = json_decode(file_get_contents('php://input'), true);
+    $user = $data['username'] ?? '';
+    $pass = $data['password'] ?? '';
+    if ($user === APP_USER && password_verify($pass, APP_PASS_HASH)) {
+        $_SESSION['user'] = $user;
+        echo json_encode(['success' => true]);
+    } else {
+        http_response_code(401);
+        echo json_encode(['error' => 'Invalid credentials']);
+    }
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'DELETE') {
+    session_destroy();
+    echo json_encode(['success' => true]);
+    exit;
+}
+
+echo json_encode(['error' => 'Unsupported method']);
+?>

--- a/views/calendar.html
+++ b/views/calendar.html
@@ -1,0 +1,2 @@
+<h2>Kalendarz</h2>
+<div id="calendar"></div>

--- a/views/dashboard.html
+++ b/views/dashboard.html
@@ -1,0 +1,9 @@
+<h2>Dashboard</h2>
+<section>
+  <h3>Nadchodzące publikacje</h3>
+  <div id="upcoming">Ładowanie...</div>
+</section>
+<section>
+  <h3>Dzisiejsze zadania</h3>
+  <ul id="todayTodos"></ul>
+</section>

--- a/views/ideas.html
+++ b/views/ideas.html
@@ -1,0 +1,2 @@
+<h2>Bank pomysłów</h2>
+<ul id="ideasList"></ul>

--- a/views/kanban.html
+++ b/views/kanban.html
@@ -1,0 +1,2 @@
+<h2>Kanban</h2>
+<div id="kanban" class="kanban"></div>

--- a/views/posts.html
+++ b/views/posts.html
@@ -1,0 +1,6 @@
+<h2>Posty</h2>
+<input id="postSearch" placeholder="Szukaj..." />
+<table class="striped">
+  <thead><tr><th>Tytuł</th><th>Platforma</th><th>Status</th></tr></thead>
+  <tbody id="postsTable"></tbody>
+</table>

--- a/views/reports.html
+++ b/views/reports.html
@@ -1,0 +1,2 @@
+<h2>Raporty</h2>
+<p>W budowie...</p>

--- a/views/settings.html
+++ b/views/settings.html
@@ -1,0 +1,9 @@
+<h2>Ustawienia</h2>
+<button id="logoutBtn">Wyloguj</button>
+<script>
+if(document.getElementById('logoutBtn')){
+  document.getElementById('logoutBtn').addEventListener('click', ()=>{
+    fetch('login.php', {method:'DELETE'}).then(()=>location.reload());
+  });
+}
+</script>

--- a/views/todos.html
+++ b/views/todos.html
@@ -1,0 +1,2 @@
+<h2>To-do</h2>
+<ul id="todoList"></ul>


### PR DESCRIPTION
## Summary
- Refresh layout with Inter font, responsive navigation and dark/light styling.
- Add searchable posts list, dashboard daily tasks, drag-and-drop kanban board and monthly calendar.
- Allow partial updates of posts for status changes.

## Testing
- `php -l index.php login.php db.php backup.php api/export.php api/todos.php api/ideas.php api/templates.php api/posts.php config.php`
- `curl -c cookies.txt -s -X POST -H 'Content-Type: application/json' -d '{"username":"admin","password":"password"}' http://localhost:8000/login.php`
- `curl -b cookies.txt -s -X PUT -H 'Content-Type: application/json' -d '{"status":"ready"}' http://localhost:8000/api/posts.php?id=1`
- `curl -b cookies.txt -s http://localhost:8000/api/posts.php`
- `curl -b cookies.txt -s http://localhost:8000/api/todos.php`


------
https://chatgpt.com/codex/tasks/task_e_689cbf2d2b0c832f8bb3d345ad39d639